### PR TITLE
Update and refactor project dependencies

### DIFF
--- a/Installer/SyncNBSParameters.aip
+++ b/Installer/SyncNBSParameters.aip
@@ -55,12 +55,12 @@
     <ROW Component="CommunityToolkit.Mvvm.dll_1" ComponentId="{620BAF1C-675A-4B27-AFEA-F65B7C7466B7}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="CommunityToolkit.Mvvm.dll_1"/>
     <ROW Component="CommunityToolkit.Mvvm.dll_2" ComponentId="{97DFF7F9-B0C0-4125-8222-A5C46C720689}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="CommunityToolkit.Mvvm.dll_2"/>
     <ROW Component="CommunityToolkit.Mvvm.dll_3" ComponentId="{12F0B265-1E6F-4462-B008-B7868D47A078}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="CommunityToolkit.Mvvm.dll_3"/>
-    <ROW Component="CommunityToolkit.Mvvm.dll_4" ComponentId="{DE98591E-A885-4397-BBEB-06851F01DF21}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="CommunityToolkit.Mvvm.dll_4"/>
+    <ROW Component="CommunityToolkit.Mvvm.dll_4" ComponentId="{DF1A5931-D65E-4CF7-BFEE-824A052BE222}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="CommunityToolkit.Mvvm.dll_4"/>
     <ROW Component="JetBrains.Annotations.dll" ComponentId="{67BE2D05-7640-4ADF-A135-483D089A55E4}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="JetBrains.Annotations.dll"/>
     <ROW Component="JetBrains.Annotations.dll_1" ComponentId="{F6C8EAA7-4641-4371-B1CC-1BBE53410A6B}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="JetBrains.Annotations.dll_1"/>
     <ROW Component="JetBrains.Annotations.dll_2" ComponentId="{6BCC13C4-ADD9-447D-9636-39FA7447C7B8}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="JetBrains.Annotations.dll_2"/>
     <ROW Component="JetBrains.Annotations.dll_3" ComponentId="{96BD2B85-3F33-4FF3-86F2-AD234D043B4C}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="JetBrains.Annotations.dll_3"/>
-    <ROW Component="JetBrains.Annotations.dll_4" ComponentId="{90A99CFE-A081-4B05-BEC7-C7BDE89FD0EE}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="JetBrains.Annotations.dll_4"/>
+    <ROW Component="JetBrains.Annotations.dll_4" ComponentId="{49DE7217-55DA-430C-BACB-90015DAA4E19}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="JetBrains.Annotations.dll_4"/>
     <ROW Component="Microsoft.Bcl.AsyncInterfaces.dll" ComponentId="{A21B024A-CD13-478B-ABD4-2B6EFB054843}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Bcl.AsyncInterfaces.dll"/>
     <ROW Component="Microsoft.Bcl.AsyncInterfaces.dll_1" ComponentId="{667D1D46-745E-42FA-BA75-975E550D3699}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Bcl.AsyncInterfaces.dll_1"/>
     <ROW Component="Microsoft.Bcl.AsyncInterfaces.dll_2" ComponentId="{BCFF7E47-8973-4D72-9755-1D7B72A4BE16}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Bcl.AsyncInterfaces.dll_2"/>
@@ -68,41 +68,41 @@
     <ROW Component="Microsoft.Extensions.Configuration.A_1_bstractions.dll" ComponentId="{0AB273DE-6E1F-411F-9290-B8015B6F2ABB}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.A_1_bstractions.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.A_2_bstractions.dll" ComponentId="{797DE047-9B02-4CE5-B29A-E667805D27FC}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.A_2_bstractions.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.A_3_bstractions.dll" ComponentId="{FFF783F9-9213-43EA-9879-50C8B9FC9151}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.A_3_bstractions.dll"/>
-    <ROW Component="Microsoft.Extensions.Configuration.A_4_bstractions.dll" ComponentId="{E35C868F-5B7D-4C31-A745-B48F0FDA3A25}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.A_4_bstractions.dll"/>
+    <ROW Component="Microsoft.Extensions.Configuration.A_4_bstractions.dll" ComponentId="{4E83ED96-AE0C-42CB-96E4-1D390907DA71}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.A_4_bstractions.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.Abstractions.dll" ComponentId="{2FCBDB81-C8D0-4C5D-B1BC-76467BB2ECE6}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.Abstractions.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.B_1_inder.dll" ComponentId="{DFBAF98C-FB36-4307-B09E-5E4BE1C0BE84}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.B_1_inder.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.B_2_inder.dll" ComponentId="{61257C5B-3FED-4256-9F1D-13490A6A46BB}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.B_2_inder.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.B_3_inder.dll" ComponentId="{A8384978-3779-41C6-BE06-BFAE6DE50E92}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.B_3_inder.dll"/>
-    <ROW Component="Microsoft.Extensions.Configuration.B_4_inder.dll" ComponentId="{F877951A-3AC6-4877-BA55-C540EFA3ACDC}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.B_4_inder.dll"/>
+    <ROW Component="Microsoft.Extensions.Configuration.B_4_inder.dll" ComponentId="{41AAA058-2845-48D4-A9CD-975CB3A9A662}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.B_4_inder.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.Binder.dll" ComponentId="{9BF31935-709D-4487-95C6-50197B08E4EA}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.Binder.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.C_1_ommandLine.dll" ComponentId="{8EB5F93C-FC4E-45B1-939D-9FA7491CE9C0}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.C_1_ommandLine.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.C_2_ommandLine.dll" ComponentId="{95BF3541-51B4-4B05-B1ED-A820A589DF39}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.C_2_ommandLine.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.C_3_ommandLine.dll" ComponentId="{25469C56-5F0E-4038-A4F4-0F79A0946A36}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.C_3_ommandLine.dll"/>
-    <ROW Component="Microsoft.Extensions.Configuration.C_4_ommandLine.dll" ComponentId="{206ECF6B-9F79-4B17-BF61-F7856750B876}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.C_4_ommandLine.dll"/>
+    <ROW Component="Microsoft.Extensions.Configuration.C_4_ommandLine.dll" ComponentId="{7309EAC8-BC02-44B7-B2EB-9E9E57A843D8}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.C_4_ommandLine.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.CommandLine.dll" ComponentId="{0567AD69-2BD7-4B1F-A43C-8EB33E5DE707}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.CommandLine.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.E_1_nvironmentVariables.dll" ComponentId="{253D49DB-DBDD-46E6-809B-8790CFC88A69}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.E_1_nvironmentVariables.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.E_2_nvironmentVariables.dll" ComponentId="{95CBE821-FF2E-4E55-852F-EFF8DA335D04}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.E_2_nvironmentVariables.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.E_3_nvironmentVariables.dll" ComponentId="{6E9F5EC3-8647-4B5D-B34E-BAA90BE001D1}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.E_3_nvironmentVariables.dll"/>
-    <ROW Component="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll" ComponentId="{5CF34F50-5450-4ECF-9952-24CBD6AA4E4E}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll"/>
+    <ROW Component="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll" ComponentId="{A1A4692D-5F08-4F0F-AEB2-8FB7E0338C9F}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.EnvironmentVariables.dll" ComponentId="{7084A798-2318-4713-A7FB-D69AAB84BD8C}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.EnvironmentVariables.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.F_1_ileExtensions.dll" ComponentId="{11B7DB8D-A165-4F44-AD91-2AA2657B22BB}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.F_1_ileExtensions.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.F_2_ileExtensions.dll" ComponentId="{E74889D4-664F-4084-B117-DAE87AA4F90F}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.F_2_ileExtensions.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.F_3_ileExtensions.dll" ComponentId="{A36D77E2-A150-4025-9E61-3B9745262B1F}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.F_3_ileExtensions.dll"/>
-    <ROW Component="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll" ComponentId="{80D82E5D-8E5E-475F-A612-E96839126AF7}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll"/>
+    <ROW Component="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll" ComponentId="{D2070CD7-AB9F-4D1A-B807-1DBB9F27C769}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.FileExtensions.dll" ComponentId="{A5A9ED1D-4F59-4E5B-BAE7-114A8651E885}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.FileExtensions.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.J_1_son.dll" ComponentId="{C608F011-F8E9-43F1-9A70-61A8A0D23FD1}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.J_1_son.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.J_2_son.dll" ComponentId="{1A198084-1AD9-495E-9C0E-7873732D3C11}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.J_2_son.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.J_3_son.dll" ComponentId="{DE7A4418-09C9-410C-94BE-C289E0D799B9}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.J_3_son.dll"/>
-    <ROW Component="Microsoft.Extensions.Configuration.J_4_son.dll" ComponentId="{566D2C97-EDC5-4B5F-9906-6025E0156549}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.J_4_son.dll"/>
+    <ROW Component="Microsoft.Extensions.Configuration.J_4_son.dll" ComponentId="{A27CDB62-F293-44AB-91E4-747969553060}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.J_4_son.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.Json.dll" ComponentId="{2928AE72-EFFF-4C0C-9FA3-155EC24D7F7D}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.Json.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.U_1_serSecrets.dll" ComponentId="{8E0E0E85-E684-430F-A8B9-8F2D119C02F6}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.U_1_serSecrets.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.U_2_serSecrets.dll" ComponentId="{993CC19E-6728-4D0F-B5A7-89679667A6F6}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.U_2_serSecrets.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.U_3_serSecrets.dll" ComponentId="{9D86DA03-B4FB-4234-BB02-42579C561419}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.U_3_serSecrets.dll"/>
-    <ROW Component="Microsoft.Extensions.Configuration.U_4_serSecrets.dll" ComponentId="{F35A4ABD-4F83-411B-A188-A4556AF3A5F7}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.U_4_serSecrets.dll"/>
+    <ROW Component="Microsoft.Extensions.Configuration.U_4_serSecrets.dll" ComponentId="{30CB287D-976A-4BDA-9CD5-974B916EBAA7}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.U_4_serSecrets.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.UserSecrets.dll" ComponentId="{A3E4BA3C-BF3F-4417-BFC6-0EB7A95EE9BE}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.UserSecrets.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.d_10_ll" ComponentId="{CFAD9BB9-DBCD-4EC4-A5BA-13C9BC55B2A6}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.dll_2"/>
     <ROW Component="Microsoft.Extensions.Configuration.d_11_ll" ComponentId="{45F1B0C8-B00E-4552-AF73-989B594570E5}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.dll_3"/>
-    <ROW Component="Microsoft.Extensions.Configuration.d_12_ll" ComponentId="{CF8B7FCD-AA11-49E0-99EC-42FC81D68902}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.dll_4"/>
+    <ROW Component="Microsoft.Extensions.Configuration.d_12_ll" ComponentId="{2571F588-0731-4E66-8F07-88CEB49DAAFF}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.dll_4"/>
     <ROW Component="Microsoft.Extensions.Configuration.dll" ComponentId="{A050DE96-6B9D-4443-A4A5-E398A62BB9E1}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.dll"/>
     <ROW Component="Microsoft.Extensions.Configuration.dll_1" ComponentId="{DC0D4376-5755-4BB0-AACF-F214B46C94C7}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Configuration.dll_1"/>
     <ROW Component="Microsoft.Extensions.DependencyInjec_1_tion.dll" ComponentId="{6461A1A5-1F26-46A0-9287-7E19B4BF9051}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjection.dll"/>
@@ -112,120 +112,122 @@
     <ROW Component="Microsoft.Extensions.DependencyInjec_5_tion.dll" ComponentId="{7DDB4194-42DF-405F-92AF-873252BC28AC}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjec_2_tion.dll"/>
     <ROW Component="Microsoft.Extensions.DependencyInjec_6_tion.Abstractions.dll" ComponentId="{2133D7C8-8012-4A3B-B80D-04ED19A4BABE}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjec_3_tion.Abstractions.dll"/>
     <ROW Component="Microsoft.Extensions.DependencyInjec_7_tion.dll" ComponentId="{F9FA7B73-9C45-4D38-9A07-86F8606BCAE2}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjec_3_tion.dll"/>
-    <ROW Component="Microsoft.Extensions.DependencyInjec_8_tion.Abstractions.dll" ComponentId="{D9DEB145-DE0A-4034-BEFB-ADF54B4A61D5}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjec_4_tion.Abstractions.dll"/>
-    <ROW Component="Microsoft.Extensions.DependencyInjec_9_tion.dll" ComponentId="{DB91106A-7703-47B8-A238-47AE03739690}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjec_4_tion.dll"/>
+    <ROW Component="Microsoft.Extensions.DependencyInjec_8_tion.Abstractions.dll" ComponentId="{6EB813F4-8976-4328-AC75-039BD811FCA1}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjec_4_tion.Abstractions.dll"/>
+    <ROW Component="Microsoft.Extensions.DependencyInjec_9_tion.dll" ComponentId="{8A0D0CEE-F4C4-4A17-BD27-DDE5B0CFB33B}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjec_4_tion.dll"/>
     <ROW Component="Microsoft.Extensions.DependencyInjection.Abstractions.dll" ComponentId="{0144942C-E382-4721-B1A7-9260DF7080B2}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.DependencyInjection.Abstractions.dll"/>
+    <ROW Component="Microsoft.Extensions.Diagnostics.Abstractions.dll" ComponentId="{C441E0FE-B2BA-4CC7-A854-B4850E9232AA}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Diagnostics.Abstractions.dll"/>
+    <ROW Component="Microsoft.Extensions.Diagnostics.dll" ComponentId="{04E3FB46-EC50-4449-92A1-11524EF124B0}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Diagnostics.dll"/>
     <ROW Component="Microsoft.Extensions.FileProviders.A_1_bstractions.dll" ComponentId="{83E76E1A-185F-4C59-8AC7-E7D79B7FFDD5}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.A_1_bstractions.dll"/>
     <ROW Component="Microsoft.Extensions.FileProviders.A_2_bstractions.dll" ComponentId="{8651C467-87DE-4E41-9E6F-F4640B80875C}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.A_2_bstractions.dll"/>
     <ROW Component="Microsoft.Extensions.FileProviders.A_3_bstractions.dll" ComponentId="{54C93352-AD1D-4098-B4E7-6645B48C9483}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.A_3_bstractions.dll"/>
-    <ROW Component="Microsoft.Extensions.FileProviders.A_4_bstractions.dll" ComponentId="{8DAFA8FD-00F6-4FDE-AA12-109B6186910E}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.A_4_bstractions.dll"/>
+    <ROW Component="Microsoft.Extensions.FileProviders.A_4_bstractions.dll" ComponentId="{A6C4312A-BEB8-4F98-BA48-B35BE8122901}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.A_4_bstractions.dll"/>
     <ROW Component="Microsoft.Extensions.FileProviders.Abstractions.dll" ComponentId="{7AE378A2-6701-492A-BACD-D7A7E94E10A5}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.Abstractions.dll"/>
     <ROW Component="Microsoft.Extensions.FileProviders.P_1_hysical.dll" ComponentId="{18B206F2-FB16-4040-9E69-1AF77F8A105A}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.P_1_hysical.dll"/>
     <ROW Component="Microsoft.Extensions.FileProviders.P_2_hysical.dll" ComponentId="{1FF0098D-3329-4912-8CBA-0D146B48798C}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.P_2_hysical.dll"/>
     <ROW Component="Microsoft.Extensions.FileProviders.P_3_hysical.dll" ComponentId="{591BB91C-4268-48DD-A45C-6F49D9EDB4B3}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.P_3_hysical.dll"/>
-    <ROW Component="Microsoft.Extensions.FileProviders.P_4_hysical.dll" ComponentId="{24140145-53D1-42F6-AEE5-0563E4203617}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.P_4_hysical.dll"/>
+    <ROW Component="Microsoft.Extensions.FileProviders.P_4_hysical.dll" ComponentId="{D2D878BC-7205-4A3B-9EC7-0E6B3C075C86}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.P_4_hysical.dll"/>
     <ROW Component="Microsoft.Extensions.FileProviders.Physical.dll" ComponentId="{01A5AE30-771B-4DFC-B7F6-E38955EA56D7}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileProviders.Physical.dll"/>
     <ROW Component="Microsoft.Extensions.FileSystemGlobb_1_ing.dll" ComponentId="{B7DF442F-38B0-4F76-A9AA-5B033BE5FEBD}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileSystemGlobb_1_ing.dll"/>
     <ROW Component="Microsoft.Extensions.FileSystemGlobb_2_ing.dll" ComponentId="{5C083B05-2717-4324-977A-ADBAD1B11638}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileSystemGlobb_2_ing.dll"/>
     <ROW Component="Microsoft.Extensions.FileSystemGlobb_3_ing.dll" ComponentId="{8B3A28BE-B1CE-4558-9DA0-432F59B5832F}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileSystemGlobb_3_ing.dll"/>
-    <ROW Component="Microsoft.Extensions.FileSystemGlobb_4_ing.dll" ComponentId="{65882613-6093-4F3A-9535-96E2E7B755DB}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileSystemGlobb_4_ing.dll"/>
+    <ROW Component="Microsoft.Extensions.FileSystemGlobb_4_ing.dll" ComponentId="{2D2A9CF4-7F3A-4591-B9D6-ED0BFE2EC1C0}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileSystemGlobb_4_ing.dll"/>
     <ROW Component="Microsoft.Extensions.FileSystemGlobbing.dll" ComponentId="{9951206D-7487-4054-8D99-11DF256FD391}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.FileSystemGlobbing.dll"/>
     <ROW Component="Microsoft.Extensions.Hosting.Abstrac_1_tions.dll" ComponentId="{DCDBFEF0-035D-4C62-88F0-B82D02240BF6}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.Abstrac_1_tions.dll"/>
     <ROW Component="Microsoft.Extensions.Hosting.Abstrac_2_tions.dll" ComponentId="{A97DAD1C-BD01-462E-A237-E5A662D9C743}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.Abstrac_2_tions.dll"/>
     <ROW Component="Microsoft.Extensions.Hosting.Abstrac_3_tions.dll" ComponentId="{04941F8B-FDC7-4B33-BE02-88BB17DFAEEF}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.Abstrac_3_tions.dll"/>
-    <ROW Component="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll" ComponentId="{8F52D076-3BE4-4D38-86DE-816AB45BCF5B}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll"/>
+    <ROW Component="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll" ComponentId="{9475FC32-71B0-4915-939E-FCB781C0F905}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll"/>
     <ROW Component="Microsoft.Extensions.Hosting.Abstractions.dll" ComponentId="{252CC5AC-A074-4835-B7FD-F15A5AFD7962}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.Abstractions.dll"/>
     <ROW Component="Microsoft.Extensions.Hosting.dll" ComponentId="{053675C5-8393-4FB9-9F2D-92A8FD33C7E7}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.dll"/>
     <ROW Component="Microsoft.Extensions.Hosting.dll_1" ComponentId="{00F5B544-3535-4ACD-B72B-A3F1E3819C1B}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.dll_1"/>
     <ROW Component="Microsoft.Extensions.Hosting.dll_2" ComponentId="{835621BA-31FF-4460-860D-49C07B351F23}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.dll_2"/>
     <ROW Component="Microsoft.Extensions.Hosting.dll_3" ComponentId="{F3721649-2806-45CE-A6EA-4652FE77E4A0}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.dll_3"/>
-    <ROW Component="Microsoft.Extensions.Hosting.dll_4" ComponentId="{A0466194-35F9-4FF1-A0DA-AD24E4204BD1}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.dll_4"/>
+    <ROW Component="Microsoft.Extensions.Hosting.dll_4" ComponentId="{1FED418A-6313-4A91-8919-22019173899D}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Hosting.dll_4"/>
     <ROW Component="Microsoft.Extensions.Logging.Abstrac_1_tions.dll" ComponentId="{D590F290-9424-4774-A9BD-E16FF746FF5A}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Abstrac_1_tions.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Abstrac_2_tions.dll" ComponentId="{E6F94EA1-8D07-4562-B09D-18495CC43C1D}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Abstrac_2_tions.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Abstrac_3_tions.dll" ComponentId="{74F09207-B762-4B7D-90BE-E4318F6DA80C}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Abstrac_3_tions.dll"/>
-    <ROW Component="Microsoft.Extensions.Logging.Abstrac_4_tions.dll" ComponentId="{DC92B509-FCCF-405D-A43F-8029AE393252}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Abstrac_4_tions.dll"/>
+    <ROW Component="Microsoft.Extensions.Logging.Abstrac_4_tions.dll" ComponentId="{235FF2E9-9B04-430B-AB80-3A40B1F4FA21}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Abstrac_4_tions.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Abstractions.dll" ComponentId="{C2EB12AB-999D-4BDA-906A-A8174DC29463}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Abstractions.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Configu_1_ration.dll" ComponentId="{8DD1FD44-F1FF-4CCE-B493-804D30F47880}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Configu_1_ration.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Configu_2_ration.dll" ComponentId="{5631E96F-B001-4F15-9252-C28ED219BC9F}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Configu_2_ration.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Configu_3_ration.dll" ComponentId="{6F553260-62B8-415C-9090-A61A320F82F1}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Configu_3_ration.dll"/>
-    <ROW Component="Microsoft.Extensions.Logging.Configu_4_ration.dll" ComponentId="{BBDE3C19-A926-49CC-94F0-D69FC8303E20}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Configu_4_ration.dll"/>
+    <ROW Component="Microsoft.Extensions.Logging.Configu_4_ration.dll" ComponentId="{CA65BA14-5567-4BD8-AAF8-D7A42D7DF16C}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Configu_4_ration.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Configuration.dll" ComponentId="{D739C98E-D6BA-444E-B43F-B817AF28E518}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Configuration.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Console.dll" ComponentId="{C5D0FD64-5982-41AD-9A7A-9AF5574A17F2}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Console.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Console_1_.dll" ComponentId="{22540DC7-4C9C-453E-B795-99E376EEFE30}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Console_1_.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Console_2_.dll" ComponentId="{0B6A7F71-D5EB-4751-88C0-60690EBF2B77}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Console_2_.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Console_3_.dll" ComponentId="{EA374EC3-7FBA-4317-9368-3CC17A8A3165}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Console_3_.dll"/>
-    <ROW Component="Microsoft.Extensions.Logging.Console_4_.dll" ComponentId="{9387588E-782A-4EB6-90D1-4FAE8FDC126D}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Console_4_.dll"/>
+    <ROW Component="Microsoft.Extensions.Logging.Console_4_.dll" ComponentId="{FB413EF1-EE87-4AD8-867F-EB7479BF91B8}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Console_4_.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Debug.d_10_ll" ComponentId="{D46D59EA-E2A2-428B-998F-E972D4C35DB7}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Debug.dll_2"/>
     <ROW Component="Microsoft.Extensions.Logging.Debug.d_11_ll" ComponentId="{7E99FD8C-6D32-4BB3-B30F-320427AE15BD}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Debug.dll_3"/>
-    <ROW Component="Microsoft.Extensions.Logging.Debug.d_12_ll" ComponentId="{C83A2267-5261-415E-8B34-275A98D6C497}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Debug.dll_4"/>
+    <ROW Component="Microsoft.Extensions.Logging.Debug.d_12_ll" ComponentId="{F6CFB3DC-9A3C-44E1-9ADE-958ACA4B25F4}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Debug.dll_4"/>
     <ROW Component="Microsoft.Extensions.Logging.Debug.dll" ComponentId="{806C3520-7014-4CA7-AAF1-7BA1D60F72AC}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Debug.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.Debug.dll_1" ComponentId="{E3AD4033-2683-4ECF-96C0-4FC4A35B4B93}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.Debug.dll_1"/>
     <ROW Component="Microsoft.Extensions.Logging.EventLo_1_g.dll" ComponentId="{A5817A75-90C8-4A30-BDF9-7EFB95A4690D}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventLo_1_g.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.EventLo_2_g.dll" ComponentId="{99D3BB8C-E49C-4C3B-B32A-D61256A6D45D}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventLo_2_g.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.EventLo_3_g.dll" ComponentId="{5135E33C-E3CF-4845-AF51-CEAB60E3D8F8}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventLo_3_g.dll"/>
-    <ROW Component="Microsoft.Extensions.Logging.EventLo_4_g.dll" ComponentId="{1CA5B359-B1C6-4187-A8AA-1A79852FAF46}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventLo_4_g.dll"/>
+    <ROW Component="Microsoft.Extensions.Logging.EventLo_4_g.dll" ComponentId="{14A1C113-596C-406D-B34E-4C1B0314FA04}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventLo_4_g.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.EventLog.dll" ComponentId="{81E65F05-3E8D-4C49-9069-00833E3878A5}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventLog.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.EventSo_1_urce.dll" ComponentId="{A4F725B2-705E-4668-A678-08E65E51DD38}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventSo_1_urce.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.EventSo_2_urce.dll" ComponentId="{053D819B-484C-4BD0-821B-D8841EB49219}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventSo_2_urce.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.EventSo_3_urce.dll" ComponentId="{BC038A0D-B1A6-40A6-8620-6C6E2C7A87BB}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventSo_3_urce.dll"/>
-    <ROW Component="Microsoft.Extensions.Logging.EventSo_4_urce.dll" ComponentId="{E5B9F6A8-02E4-4163-87F4-53028C95E89F}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventSo_4_urce.dll"/>
+    <ROW Component="Microsoft.Extensions.Logging.EventSo_4_urce.dll" ComponentId="{910DBCCA-1FFD-4EFF-A6FC-59D33D6B4054}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventSo_4_urce.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.EventSource.dll" ComponentId="{EF2E8D9A-5D40-49D2-93B0-AED33CCC337C}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.EventSource.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.dll" ComponentId="{017C45E3-69D0-4D27-8A8E-059C39D7DF10}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.dll"/>
     <ROW Component="Microsoft.Extensions.Logging.dll_1" ComponentId="{3A8898A5-5039-48BF-8934-20159F36F3DA}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.dll_1"/>
     <ROW Component="Microsoft.Extensions.Logging.dll_2" ComponentId="{4B53F955-D676-4F45-8BED-41C9D88EF5A7}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.dll_2"/>
     <ROW Component="Microsoft.Extensions.Logging.dll_3" ComponentId="{E626951D-FC55-4E33-B259-D4972A206A23}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.dll_3"/>
-    <ROW Component="Microsoft.Extensions.Logging.dll_4" ComponentId="{438BF90D-5408-48B8-BFDA-491DB606FF52}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.dll_4"/>
+    <ROW Component="Microsoft.Extensions.Logging.dll_4" ComponentId="{0F95850C-CDBB-4807-8A5E-69DBA51D168A}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Logging.dll_4"/>
     <ROW Component="Microsoft.Extensions.Options.Configu_1_rationExtensions.dll" ComponentId="{B0EF557A-4147-4D94-BD20-62AC6A782266}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.Configu_1_rationExtensions.dll"/>
     <ROW Component="Microsoft.Extensions.Options.Configu_2_rationExtensions.dll" ComponentId="{8B2748E8-389F-4842-A84C-899FD4C8B822}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.Configu_2_rationExtensions.dll"/>
     <ROW Component="Microsoft.Extensions.Options.Configu_3_rationExtensions.dll" ComponentId="{CCCD3F83-78AE-4B5F-A3E8-0FA11D1D619D}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.Configu_3_rationExtensions.dll"/>
-    <ROW Component="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll" ComponentId="{E70D0869-CDA4-4988-8954-5CB2D682E48A}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll"/>
+    <ROW Component="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll" ComponentId="{3B34BE6B-8C7D-4BAD-B47F-DB842E268F7D}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll"/>
     <ROW Component="Microsoft.Extensions.Options.ConfigurationExtensions.dll" ComponentId="{9D0CC2C5-3107-4F43-84CA-D6016D56DAE1}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.ConfigurationExtensions.dll"/>
     <ROW Component="Microsoft.Extensions.Options.dll" ComponentId="{6C2F756F-02C8-4775-8773-BC89774F391A}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.dll"/>
     <ROW Component="Microsoft.Extensions.Options.dll_1" ComponentId="{2376627F-5BD9-4196-870E-AB64F37E97BB}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.dll_1"/>
     <ROW Component="Microsoft.Extensions.Options.dll_2" ComponentId="{73CD4DC6-A24E-4AA3-9FE1-D275B965C6D1}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.dll_2"/>
     <ROW Component="Microsoft.Extensions.Options.dll_3" ComponentId="{F7DED1D8-9C3D-4A18-B48E-525CB56A0FDA}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.dll_3"/>
-    <ROW Component="Microsoft.Extensions.Options.dll_4" ComponentId="{10448C52-7E78-4234-A13C-971D1A125D1B}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.dll_4"/>
+    <ROW Component="Microsoft.Extensions.Options.dll_4" ComponentId="{47BFF5D5-54CD-4FB0-AFBB-0FD32C1B9D09}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Options.dll_4"/>
     <ROW Component="Microsoft.Extensions.Primitives.dll" ComponentId="{518C1B0B-D55F-4B3B-AE50-C07362AA03CA}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Primitives.dll"/>
     <ROW Component="Microsoft.Extensions.Primitives.dll_1" ComponentId="{F8EBEFCA-A8D1-419C-AE1E-7208422F544F}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Primitives.dll_1"/>
     <ROW Component="Microsoft.Extensions.Primitives.dll_2" ComponentId="{B66A1277-660A-428F-872B-F17259801CFF}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Primitives.dll_2"/>
     <ROW Component="Microsoft.Extensions.Primitives.dll_3" ComponentId="{BA03342E-A9DE-484D-8E59-2D535AE012F5}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Primitives.dll_3"/>
-    <ROW Component="Microsoft.Extensions.Primitives.dll_4" ComponentId="{131B9190-7074-4555-B4FD-3FADE04C62A1}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Primitives.dll_4"/>
+    <ROW Component="Microsoft.Extensions.Primitives.dll_4" ComponentId="{E8D56442-7E62-441F-99C7-7E5D24135EC7}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Microsoft.Extensions.Primitives.dll_4"/>
     <ROW Component="Nice3point.Revit.Extensions.dll" ComponentId="{1FD1EC49-1DF3-4CE8-98D4-C36FFAA5A714}" Directory_="NewFolder_Dir" Attributes="256" KeyPath="Nice3point.Revit.Extensions.dll"/>
     <ROW Component="Nice3point.Revit.Extensions.dll_1" ComponentId="{A18496EF-DBC2-4BFF-97C1-05AD7A6B27AA}" Directory_="SyncNBSParameters_Dir" Attributes="256" KeyPath="Nice3point.Revit.Extensions.dll_1"/>
     <ROW Component="Nice3point.Revit.Extensions.dll_2" ComponentId="{C99CA0CC-9BDC-4052-9627-C6DC4C97FCF1}" Directory_="SyncNBSParameters_1_Dir" Attributes="256" KeyPath="Nice3point.Revit.Extensions.dll_2"/>
     <ROW Component="Nice3point.Revit.Extensions.dll_3" ComponentId="{F4D2A584-4B50-4C4F-AE16-FC06ED19E4A6}" Directory_="SyncNBSParameters_2_Dir" Attributes="256" KeyPath="Nice3point.Revit.Extensions.dll_3"/>
-    <ROW Component="Nice3point.Revit.Extensions.dll_4" ComponentId="{1542009F-F4DD-4809-A5DD-1CF9D6F28FF7}" Directory_="SyncNBSParameters_3_Dir" Attributes="256" KeyPath="Nice3point.Revit.Extensions.dll_4"/>
+    <ROW Component="Nice3point.Revit.Extensions.dll_4" ComponentId="{4FBC9E76-CC4A-4213-819D-814AC8154C5F}" Directory_="SyncNBSParameters_3_Dir" Attributes="256" KeyPath="Nice3point.Revit.Extensions.dll_4"/>
     <ROW Component="Nice3point.Revit.Toolkit.dll" ComponentId="{C0A2784E-E510-49A4-82A1-1DBBC99C7162}" Directory_="NewFolder_Dir" Attributes="256" KeyPath="Nice3point.Revit.Toolkit.dll"/>
     <ROW Component="Nice3point.Revit.Toolkit.dll_1" ComponentId="{A04424CA-4541-4A70-8446-9EC3E0EF4047}" Directory_="SyncNBSParameters_Dir" Attributes="256" KeyPath="Nice3point.Revit.Toolkit.dll_1"/>
     <ROW Component="Nice3point.Revit.Toolkit.dll_2" ComponentId="{4225E1FD-B171-4D98-A0FB-2C39226AC46B}" Directory_="SyncNBSParameters_1_Dir" Attributes="256" KeyPath="Nice3point.Revit.Toolkit.dll_2"/>
     <ROW Component="Nice3point.Revit.Toolkit.dll_3" ComponentId="{E26722A5-AA33-44FA-BE7B-D96EC66F67F3}" Directory_="SyncNBSParameters_2_Dir" Attributes="256" KeyPath="Nice3point.Revit.Toolkit.dll_3"/>
-    <ROW Component="Nice3point.Revit.Toolkit.dll_4" ComponentId="{3A800676-813D-4222-ADC5-5AACBCABAFFD}" Directory_="SyncNBSParameters_3_Dir" Attributes="256" KeyPath="Nice3point.Revit.Toolkit.dll_4"/>
+    <ROW Component="Nice3point.Revit.Toolkit.dll_4" ComponentId="{4B083B0B-264E-4EE4-A0D8-DE9B7F0A3B3E}" Directory_="SyncNBSParameters_3_Dir" Attributes="256" KeyPath="Nice3point.Revit.Toolkit.dll_4"/>
     <ROW Component="ProductInformation" ComponentId="{CF4F8668-03DC-446D-9E71-BEB7CAD93573}" Directory_="APPDIR" Attributes="4" KeyPath="Version"/>
     <ROW Component="Serilog.Extensions.Hosting.dll" ComponentId="{9387F259-6F89-419E-AD30-F32804A04CDA}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Serilog.Extensions.Hosting.dll"/>
     <ROW Component="Serilog.Extensions.Hosting.dll_1" ComponentId="{9854D94B-999C-4D1D-84FD-9D446CA38661}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Serilog.Extensions.Hosting.dll_1"/>
     <ROW Component="Serilog.Extensions.Hosting.dll_2" ComponentId="{27B4D348-31A4-4E46-894A-6208093B7758}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Serilog.Extensions.Hosting.dll_2"/>
     <ROW Component="Serilog.Extensions.Hosting.dll_3" ComponentId="{39BB4F5E-B30F-4452-B82D-CCF5F70AAB14}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Serilog.Extensions.Hosting.dll_3"/>
-    <ROW Component="Serilog.Extensions.Hosting.dll_4" ComponentId="{0A0B2274-933A-4EBA-9472-4D4C7395EE0B}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.Extensions.Hosting.dll_4"/>
+    <ROW Component="Serilog.Extensions.Hosting.dll_4" ComponentId="{3B9F34C9-02B1-41A1-883C-D40166CE8717}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.Extensions.Hosting.dll_4"/>
     <ROW Component="Serilog.Extensions.Logging.dll" ComponentId="{7A94E7B6-5A04-440A-A344-0F3956E8323D}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Serilog.Extensions.Logging.dll"/>
     <ROW Component="Serilog.Extensions.Logging.dll_1" ComponentId="{B43F2D93-F82F-4FBD-A20B-EA49ABEEB1ED}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Serilog.Extensions.Logging.dll_1"/>
     <ROW Component="Serilog.Extensions.Logging.dll_2" ComponentId="{A12B2CF9-9F3B-49EF-A874-BAC919D448E8}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Serilog.Extensions.Logging.dll_2"/>
     <ROW Component="Serilog.Extensions.Logging.dll_3" ComponentId="{F36B68F7-22D6-4308-A21D-DED77725DC4B}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Serilog.Extensions.Logging.dll_3"/>
-    <ROW Component="Serilog.Extensions.Logging.dll_4" ComponentId="{2CE6267D-099F-43C0-A315-C74F01D2363F}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.Extensions.Logging.dll_4"/>
+    <ROW Component="Serilog.Extensions.Logging.dll_4" ComponentId="{32672A7A-20BF-4037-B715-707F506057DA}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.Extensions.Logging.dll_4"/>
     <ROW Component="Serilog.Sinks.Debug.dll" ComponentId="{F778015E-41CE-4775-B338-E80CFE3432DE}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Serilog.Sinks.Debug.dll"/>
     <ROW Component="Serilog.Sinks.Debug.dll_1" ComponentId="{93AE60BA-9894-4D21-9573-4AAA0EFA474D}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Serilog.Sinks.Debug.dll_1"/>
     <ROW Component="Serilog.Sinks.Debug.dll_2" ComponentId="{0AFE43A4-BEAC-4B83-ADCB-C6A3D18F30F1}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Serilog.Sinks.Debug.dll_2"/>
     <ROW Component="Serilog.Sinks.Debug.dll_3" ComponentId="{382B3C06-A57A-4089-88BB-A177D47DB6BE}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Serilog.Sinks.Debug.dll_3"/>
-    <ROW Component="Serilog.Sinks.Debug.dll_4" ComponentId="{5086EA89-689A-4E06-9ABC-AD1DE8AA3E1D}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.Sinks.Debug.dll_4"/>
+    <ROW Component="Serilog.Sinks.Debug.dll_4" ComponentId="{E4A66C0B-12EC-408C-ABBA-FC3A67D2927C}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.Sinks.Debug.dll_4"/>
     <ROW Component="Serilog.Sinks.File.dll" ComponentId="{AA4417F8-48D0-474B-B611-519902422BA5}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Serilog.Sinks.File.dll"/>
     <ROW Component="Serilog.Sinks.File.dll_1" ComponentId="{6723430D-6E70-4F50-B06D-7AAD240BBF7B}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Serilog.Sinks.File.dll_1"/>
     <ROW Component="Serilog.Sinks.File.dll_2" ComponentId="{C415AE4A-3474-4B77-9B84-2FEE1581C723}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Serilog.Sinks.File.dll_2"/>
     <ROW Component="Serilog.Sinks.File.dll_3" ComponentId="{4DE5C1BE-E51F-4376-9997-53AC57B431BE}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Serilog.Sinks.File.dll_3"/>
-    <ROW Component="Serilog.Sinks.File.dll_4" ComponentId="{3FE1EDCF-E9FA-4CF6-A9B3-3E05DC461950}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.Sinks.File.dll_4"/>
+    <ROW Component="Serilog.Sinks.File.dll_4" ComponentId="{164D3DDE-570D-42E0-BD9D-A7D306F6E709}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.Sinks.File.dll_4"/>
     <ROW Component="Serilog.dll" ComponentId="{A17C8281-9DF5-4B4F-B24C-4EBEE314C462}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Serilog.dll"/>
     <ROW Component="Serilog.dll_1" ComponentId="{0F709882-CD01-4DF9-BCE5-C51292EC10B8}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Serilog.dll_1"/>
     <ROW Component="Serilog.dll_2" ComponentId="{7B7D1569-3959-49BF-A5F9-A84340B973DB}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Serilog.dll_2"/>
     <ROW Component="Serilog.dll_3" ComponentId="{F6FAB1B1-4311-48B8-92A6-03E7D015C267}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Serilog.dll_3"/>
-    <ROW Component="Serilog.dll_4" ComponentId="{1955F969-0352-4E91-8FF8-30C50C5BEDEF}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.dll_4"/>
+    <ROW Component="Serilog.dll_4" ComponentId="{0B28A4FB-7954-40A8-9EE6-9D8DE09BF6C4}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Serilog.dll_4"/>
     <ROW Component="SharedParameters.txt" ComponentId="{F7B9BA7A-93D1-4159-A533-DAC6EB7CA566}" Directory_="Resources_Dir" Attributes="0" KeyPath="SharedParameters.txt" Type="0"/>
     <ROW Component="SharedParameters.txt_1" ComponentId="{29CE2982-92FB-474C-B51F-337D48D7E789}" Directory_="Resources_1_Dir" Attributes="0" KeyPath="SharedParameters.txt_1" Type="0"/>
     <ROW Component="SharedParameters.txt_2" ComponentId="{51C04A19-174D-41CF-8798-28150A66145B}" Directory_="Resources_2_Dir" Attributes="0" KeyPath="SharedParameters.txt_2" Type="0"/>
@@ -235,37 +237,33 @@
     <ROW Component="SyncNBSParameters.addin_1" ComponentId="{AABB8E1C-5663-4BB1-ADA5-448E82072AB8}" Directory_="__1_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_1" Type="0"/>
     <ROW Component="SyncNBSParameters.addin_2" ComponentId="{758DB0C1-DD1C-4DBE-864C-AD295A8DAAD1}" Directory_="__2_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_2" Type="0"/>
     <ROW Component="SyncNBSParameters.addin_3" ComponentId="{B0818EAD-0D57-49A1-8FA5-44D714057782}" Directory_="__3_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_3" Type="0"/>
-    <ROW Component="SyncNBSParameters.addin_4" ComponentId="{BB876106-7516-44B6-9093-8639671D63B7}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_4" Type="0"/>
-    <ROW Component="SyncNBSParameters.addin_5" ComponentId="{4EACF564-675F-4BA2-AD45-447B25B280D7}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_5" Type="0"/>
-    <ROW Component="SyncNBSParameters.addin_6" ComponentId="{0E6AF1EE-C742-4572-A493-9A6C79B5534B}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_6" Type="0"/>
-    <ROW Component="SyncNBSParameters.addin_7" ComponentId="{08B35B57-0EAB-4BC8-8203-8870180217AA}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_7" Type="0"/>
-    <ROW Component="SyncNBSParameters.addin_8" ComponentId="{2E049EAB-76D0-49A3-92DE-5F9A97E548D4}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_8" Type="0"/>
     <ROW Component="SyncNBSParameters.addin_9" ComponentId="{CAC00431-4790-4081-B4D2-B9618A88309E}" Directory_="__4_Dir" Attributes="0" KeyPath="SyncNBSParameters.addin_9" Type="0"/>
+    <ROW Component="SyncNBSParameters.deps.json" ComponentId="{34149180-18D1-4D09-A568-6DA3F05505C5}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="SyncNBSParameters.deps.json" Type="0"/>
     <ROW Component="SyncNBSParameters.dll" ComponentId="{3A51DAF4-1958-4E9C-BB5D-77A40293C961}" Directory_="NewFolder_Dir" Attributes="256" KeyPath="SyncNBSParameters.dll"/>
     <ROW Component="SyncNBSParameters.dll_1" ComponentId="{65D1C619-F2CE-4888-AA78-9DD9785C2FD5}" Directory_="SyncNBSParameters_Dir" Attributes="256" KeyPath="SyncNBSParameters.dll_1"/>
     <ROW Component="SyncNBSParameters.dll_2" ComponentId="{284A7C25-7731-4622-8EE9-6B2AF8534EEA}" Directory_="SyncNBSParameters_1_Dir" Attributes="256" KeyPath="SyncNBSParameters.dll_2"/>
     <ROW Component="SyncNBSParameters.dll_3" ComponentId="{3ADB5FCE-13CE-4DD9-8A0B-B4288C99BCD4}" Directory_="SyncNBSParameters_2_Dir" Attributes="256" KeyPath="SyncNBSParameters.dll_3"/>
-    <ROW Component="SyncNBSParameters.dll_4" ComponentId="{1FEFDE67-B6AB-4DF4-92E0-BF3D7AE08639}" Directory_="SyncNBSParameters_3_Dir" Attributes="256" KeyPath="SyncNBSParameters.dll_4"/>
+    <ROW Component="SyncNBSParameters.dll_4" ComponentId="{0304A50F-1BAF-400C-A796-0747CB35C5F0}" Directory_="SyncNBSParameters_3_Dir" Attributes="256" KeyPath="SyncNBSParameters.dll_4"/>
     <ROW Component="Syncfusion.Data.WPF.dll" ComponentId="{DF3F72B7-5151-4771-AC28-C3BFC9292131}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Syncfusion.Data.WPF.dll"/>
     <ROW Component="Syncfusion.Data.WPF.dll_1" ComponentId="{CE2AD3EC-B8B8-4AC3-B440-D82D63E29371}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Syncfusion.Data.WPF.dll_1"/>
     <ROW Component="Syncfusion.Data.WPF.dll_2" ComponentId="{3DE4803A-6C12-42F1-A333-60753E4894E6}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Syncfusion.Data.WPF.dll_2"/>
     <ROW Component="Syncfusion.Data.WPF.dll_3" ComponentId="{91EA6238-6220-40CC-8BD4-76AC9835C7B9}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Syncfusion.Data.WPF.dll_3"/>
-    <ROW Component="Syncfusion.Data.WPF.dll_4" ComponentId="{DA5C7159-EE7D-4253-8A04-375CCBE018D0}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Syncfusion.Data.WPF.dll_4"/>
+    <ROW Component="Syncfusion.Data.WPF.dll_4" ComponentId="{9D2A6CDB-4522-4A54-A4CD-59F28CB02CB1}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Syncfusion.Data.WPF.dll_4"/>
     <ROW Component="Syncfusion.Licensing.dll" ComponentId="{2F7263DF-CB6B-44D1-8E43-983E6FD2588F}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Syncfusion.Licensing.dll"/>
     <ROW Component="Syncfusion.Licensing.dll_1" ComponentId="{8DFC2C1A-1588-412B-805C-D6F3C413C01B}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Syncfusion.Licensing.dll_1"/>
     <ROW Component="Syncfusion.Licensing.dll_2" ComponentId="{CAF5FDC7-0F2A-4A90-87CF-33A3806B2D7C}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Syncfusion.Licensing.dll_2"/>
     <ROW Component="Syncfusion.Licensing.dll_3" ComponentId="{6FA40183-3AA9-4D61-B5D9-6C6BDA4E77C3}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Syncfusion.Licensing.dll_3"/>
-    <ROW Component="Syncfusion.Licensing.dll_4" ComponentId="{00413D2F-2DD3-4A26-B1E3-6129174A5653}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Syncfusion.Licensing.dll_4"/>
+    <ROW Component="Syncfusion.Licensing.dll_4" ComponentId="{883A5A8B-4034-4DFF-AF2E-5975CC4A9303}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Syncfusion.Licensing.dll_4"/>
     <ROW Component="Syncfusion.SfGrid.WPF.dll" ComponentId="{D3591A9A-0213-4EC3-B70D-A53AC06A45D4}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Syncfusion.SfGrid.WPF.dll"/>
     <ROW Component="Syncfusion.SfGrid.WPF.dll_1" ComponentId="{0CD9E491-86C4-460A-B413-69C2ECC59D57}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Syncfusion.SfGrid.WPF.dll_1"/>
     <ROW Component="Syncfusion.SfGrid.WPF.dll_2" ComponentId="{F95D3F9D-C3A4-4FA9-92B3-301756283128}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Syncfusion.SfGrid.WPF.dll_2"/>
     <ROW Component="Syncfusion.SfGrid.WPF.dll_3" ComponentId="{FCBB52F9-73E7-4125-AB1C-B1D3E21121C3}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Syncfusion.SfGrid.WPF.dll_3"/>
-    <ROW Component="Syncfusion.SfGrid.WPF.dll_4" ComponentId="{A10CD90C-B045-4C68-915A-5606A812AB9F}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Syncfusion.SfGrid.WPF.dll_4"/>
+    <ROW Component="Syncfusion.SfGrid.WPF.dll_4" ComponentId="{15897B2C-380C-4876-9E53-C90790B935CC}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Syncfusion.SfGrid.WPF.dll_4"/>
     <ROW Component="Syncfusion.Shared.WPF.dll" ComponentId="{AB58C439-9E07-4FB0-B45B-BB9A41AA67B6}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="Syncfusion.Shared.WPF.dll"/>
     <ROW Component="Syncfusion.Shared.WPF.dll_1" ComponentId="{C12F3624-1086-4A88-9890-E6CCB5080A86}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="Syncfusion.Shared.WPF.dll_1"/>
     <ROW Component="Syncfusion.Shared.WPF.dll_2" ComponentId="{B0614FF4-0187-4DA2-9249-7FF10AC18A6D}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="Syncfusion.Shared.WPF.dll_2"/>
     <ROW Component="Syncfusion.Shared.WPF.dll_3" ComponentId="{640F29BB-A06E-44D4-8990-CA5DF60834FD}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="Syncfusion.Shared.WPF.dll_3"/>
-    <ROW Component="Syncfusion.Shared.WPF.dll_4" ComponentId="{61A7CA62-142B-4C5A-881B-9296F15783B2}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Syncfusion.Shared.WPF.dll_4"/>
+    <ROW Component="Syncfusion.Shared.WPF.dll_4" ComponentId="{0A7659E5-9318-40BA-8D59-079AEC20CE76}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="Syncfusion.Shared.WPF.dll_4"/>
     <ROW Component="System.Buffers.dll" ComponentId="{969EC7B8-9336-40EE-89EF-E65CB2BE9652}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="System.Buffers.dll"/>
     <ROW Component="System.Buffers.dll_1" ComponentId="{45FD21E2-9A6E-4EBE-9CE1-F777AD386888}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="System.Buffers.dll_1"/>
     <ROW Component="System.Buffers.dll_2" ComponentId="{1DC826D7-635D-4329-8BE8-0D83A548F3B0}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="System.Buffers.dll_2"/>
@@ -310,7 +308,7 @@
     <ROW Component="ricaun.Revit.UI.StatusBar.1.0.0.dll_1" ComponentId="{255B060C-BBDE-4483-9B0D-EF0A7280605A}" Directory_="SyncNBSParameters_Dir" Attributes="0" KeyPath="ricaun.Revit.UI.StatusBar.1.0.0.dll_1"/>
     <ROW Component="ricaun.Revit.UI.StatusBar.1.0.0.dll_2" ComponentId="{A8E51F78-089E-46F3-88AC-886408E8354F}" Directory_="SyncNBSParameters_1_Dir" Attributes="0" KeyPath="ricaun.Revit.UI.StatusBar.1.0.0.dll_2"/>
     <ROW Component="ricaun.Revit.UI.StatusBar.1.0.0.dll_3" ComponentId="{C53EFED2-0001-4E45-BCF4-2D7717B37480}" Directory_="SyncNBSParameters_2_Dir" Attributes="0" KeyPath="ricaun.Revit.UI.StatusBar.1.0.0.dll_3"/>
-    <ROW Component="ricaun.Revit.UI.StatusBar.1.0.0.dll_4" ComponentId="{AD29A361-E683-44BD-9444-FEB21CE345FE}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="ricaun.Revit.UI.StatusBar.1.0.0.dll_4"/>
+    <ROW Component="ricaun.Revit.UI.StatusBar.1.0.0.dll_4" ComponentId="{1F705185-B1DE-406F-8552-E129CAA7308A}" Directory_="SyncNBSParameters_3_Dir" Attributes="0" KeyPath="ricaun.Revit.UI.StatusBar.1.0.0.dll_4"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiFeatsComponent">
     <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0"/>
@@ -357,7 +355,6 @@
     <ROW File="Serilog.Extensions.Logging.dll" Component_="Serilog.Extensions.Logging.dll" FileName="SERILO~2.DLL|Serilog.Extensions.Logging.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R21\Serilog.Extensions.Logging.dll" SelfReg="false"/>
     <ROW File="Serilog.Sinks.Debug.dll" Component_="Serilog.Sinks.Debug.dll" FileName="SERILO~3.DLL|Serilog.Sinks.Debug.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R21\Serilog.Sinks.Debug.dll" SelfReg="false"/>
     <ROW File="Serilog.Sinks.File.dll" Component_="Serilog.Sinks.File.dll" FileName="SERILO~4.DLL|Serilog.Sinks.File.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R21\Serilog.Sinks.File.dll" SelfReg="false"/>
-    <ROW File="SyncNBSParameters.addin_4" Component_="SyncNBSParameters.addin_4" FileName="SYNCNB~1.ADD|SyncNBSParameters.addin" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R21\SyncNBSParameters.addin" SelfReg="false"/>
     <ROW File="SyncNBSParameters.dll" Component_="SyncNBSParameters.dll" FileName="SYNCNB~1.DLL|SyncNBSParameters.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R21\SyncNBSParameters.dll" SelfReg="false"/>
     <ROW File="System.Buffers.dll" Component_="System.Buffers.dll" FileName="SYSTEM~1.DLL|System.Buffers.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R21\System.Buffers.dll" SelfReg="false"/>
     <ROW File="System.ComponentModel.Annotations.dll" Component_="System.ComponentModel.Annotations.dll" FileName="SYSTEM~2.DLL|System.ComponentModel.Annotations.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R21\System.ComponentModel.Annotations.dll" SelfReg="false"/>
@@ -377,7 +374,6 @@
     <ROW File="Serilog.Extensions.Logging.dll_1" Component_="Serilog.Extensions.Logging.dll_1" FileName="SERILO~2.DLL|Serilog.Extensions.Logging.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R22\Serilog.Extensions.Logging.dll" SelfReg="false"/>
     <ROW File="Serilog.Sinks.Debug.dll_1" Component_="Serilog.Sinks.Debug.dll_1" FileName="SERILO~3.DLL|Serilog.Sinks.Debug.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R22\Serilog.Sinks.Debug.dll" SelfReg="false"/>
     <ROW File="Serilog.Sinks.File.dll_1" Component_="Serilog.Sinks.File.dll_1" FileName="SERILO~4.DLL|Serilog.Sinks.File.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R22\Serilog.Sinks.File.dll" SelfReg="false"/>
-    <ROW File="SyncNBSParameters.addin_5" Component_="SyncNBSParameters.addin_5" FileName="SYNCNB~1.ADD|SyncNBSParameters.addin" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R22\SyncNBSParameters.addin" SelfReg="false"/>
     <ROW File="SyncNBSParameters.dll_1" Component_="SyncNBSParameters.dll_1" FileName="SYNCNB~1.DLL|SyncNBSParameters.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R22\SyncNBSParameters.dll" SelfReg="false"/>
     <ROW File="System.Buffers.dll_1" Component_="System.Buffers.dll_1" FileName="SYSTEM~1.DLL|System.Buffers.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R22\System.Buffers.dll" SelfReg="false"/>
     <ROW File="System.ComponentModel.Annotations.dll_1" Component_="System.ComponentModel.Annotations.dll_1" FileName="SYSTEM~2.DLL|System.ComponentModel.Annotations.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R22\System.ComponentModel.Annotations.dll" SelfReg="false"/>
@@ -429,7 +425,6 @@
     <ROW File="Serilog.Extensions.Logging.dll_2" Component_="Serilog.Extensions.Logging.dll_2" FileName="SERILO~2.DLL|Serilog.Extensions.Logging.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R23\Serilog.Extensions.Logging.dll" SelfReg="false"/>
     <ROW File="Serilog.Sinks.Debug.dll_2" Component_="Serilog.Sinks.Debug.dll_2" FileName="SERILO~3.DLL|Serilog.Sinks.Debug.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R23\Serilog.Sinks.Debug.dll" SelfReg="false"/>
     <ROW File="Serilog.Sinks.File.dll_2" Component_="Serilog.Sinks.File.dll_2" FileName="SERILO~4.DLL|Serilog.Sinks.File.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R23\Serilog.Sinks.File.dll" SelfReg="false"/>
-    <ROW File="SyncNBSParameters.addin_6" Component_="SyncNBSParameters.addin_6" FileName="SYNCNB~1.ADD|SyncNBSParameters.addin" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R23\SyncNBSParameters.addin" SelfReg="false"/>
     <ROW File="SyncNBSParameters.dll_2" Component_="SyncNBSParameters.dll_2" FileName="SYNCNB~1.DLL|SyncNBSParameters.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R23\SyncNBSParameters.dll" SelfReg="false"/>
     <ROW File="System.Buffers.dll_2" Component_="System.Buffers.dll_2" FileName="SYSTEM~1.DLL|System.Buffers.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R23\System.Buffers.dll" SelfReg="false"/>
     <ROW File="System.ComponentModel.Annotations.dll_2" Component_="System.ComponentModel.Annotations.dll_2" FileName="SYSTEM~2.DLL|System.ComponentModel.Annotations.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R23\System.ComponentModel.Annotations.dll" SelfReg="false"/>
@@ -505,7 +500,6 @@
     <ROW File="Serilog.Extensions.Logging.dll_3" Component_="Serilog.Extensions.Logging.dll_3" FileName="SERILO~2.DLL|Serilog.Extensions.Logging.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\Serilog.Extensions.Logging.dll" SelfReg="false"/>
     <ROW File="Serilog.Sinks.Debug.dll_3" Component_="Serilog.Sinks.Debug.dll_3" FileName="SERILO~3.DLL|Serilog.Sinks.Debug.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\Serilog.Sinks.Debug.dll" SelfReg="false"/>
     <ROW File="Serilog.Sinks.File.dll_3" Component_="Serilog.Sinks.File.dll_3" FileName="SERILO~4.DLL|Serilog.Sinks.File.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\Serilog.Sinks.File.dll" SelfReg="false"/>
-    <ROW File="SyncNBSParameters.addin_7" Component_="SyncNBSParameters.addin_7" FileName="SYNCNB~1.ADD|SyncNBSParameters.addin" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\SyncNBSParameters.addin" SelfReg="false"/>
     <ROW File="SyncNBSParameters.dll_3" Component_="SyncNBSParameters.dll_3" FileName="SYNCNB~1.DLL|SyncNBSParameters.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\SyncNBSParameters.dll" SelfReg="false"/>
     <ROW File="System.Buffers.dll_3" Component_="System.Buffers.dll_3" FileName="SYSTEM~1.DLL|System.Buffers.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\System.Buffers.dll" SelfReg="false"/>
     <ROW File="System.ComponentModel.Annotations.dll_3" Component_="System.ComponentModel.Annotations.dll_3" FileName="SYSTEM~2.DLL|System.ComponentModel.Annotations.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\System.ComponentModel.Annotations.dll" SelfReg="false"/>
@@ -533,12 +527,31 @@
     <ROW File="Syncfusion.Licensing.dll_3" Component_="Syncfusion.Licensing.dll_3" FileName="SYNCFU~2.DLL|Syncfusion.Licensing.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\Syncfusion.Licensing.dll" SelfReg="false"/>
     <ROW File="Syncfusion.SfGrid.WPF.dll_3" Component_="Syncfusion.SfGrid.WPF.dll_3" FileName="SYNCFU~3.DLL|Syncfusion.SfGrid.WPF.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\Syncfusion.SfGrid.WPF.dll" SelfReg="false"/>
     <ROW File="Syncfusion.Shared.WPF.dll_3" Component_="Syncfusion.Shared.WPF.dll_3" FileName="SYNCFU~4.DLL|Syncfusion.Shared.WPF.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R24\Syncfusion.Shared.WPF.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Logging.dll_4" Component_="Microsoft.Extensions.Logging.dll_4" FileName="MICROS~1.DLL|Microsoft.Extensions.Logging.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Logging.EventLo_4_g.dll" Component_="Microsoft.Extensions.Logging.EventLo_4_g.dll" FileName="MICROS~2.DLL|Microsoft.Extensions.Logging.EventLog.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.EventLog.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Logging.EventSo_4_urce.dll" Component_="Microsoft.Extensions.Logging.EventSo_4_urce.dll" FileName="MICROS~3.DLL|Microsoft.Extensions.Logging.EventSource.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.EventSource.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll" Component_="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll" FileName="MICROS~4.DLL|Microsoft.Extensions.Options.ConfigurationExtensions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Options.ConfigurationExtensions.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Options.dll_4" Component_="Microsoft.Extensions.Options.dll_4" FileName="MICROS~5.DLL|Microsoft.Extensions.Options.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Options.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Primitives.dll_4" Component_="Microsoft.Extensions.Primitives.dll_4" FileName="MICROS~6.DLL|Microsoft.Extensions.Primitives.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Primitives.dll" SelfReg="false"/>
+    <ROW File="SharedParameters.txt_4" Component_="SharedParameters.txt_4" FileName="SHARED~1.TXT|SharedParameters.txt" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Resources\SharedParameters.txt" SelfReg="false"/>
+    <ROW File="SyncNBSParameters.addin_9" Component_="SyncNBSParameters.addin_9" FileName="SYNCNB~1.ADD|SyncNBSParameters.addin" Attributes="0" SourcePath="..\SyncNBSParameters\SyncNBSParameters.addin" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll" Component_="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll" FileName="MICROS~1.DLL|Microsoft.Extensions.Configuration.EnvironmentVariables.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll" Component_="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll" FileName="MICROS~2.DLL|Microsoft.Extensions.Configuration.FileExtensions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.FileExtensions.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Configuration.J_4_son.dll" Component_="Microsoft.Extensions.Configuration.J_4_son.dll" FileName="MICROS~3.DLL|Microsoft.Extensions.Configuration.Json.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.Json.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Configuration.U_4_serSecrets.dll" Component_="Microsoft.Extensions.Configuration.U_4_serSecrets.dll" FileName="MICROS~4.DLL|Microsoft.Extensions.Configuration.UserSecrets.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.UserSecrets.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.DependencyInjec_4_tion.Abstractions.dll" Component_="Microsoft.Extensions.DependencyInjec_8_tion.Abstractions.dll" FileName="MICROS~5.DLL|Microsoft.Extensions.DependencyInjection.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.DependencyInjection.Abstractions.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.DependencyInjec_4_tion.dll" Component_="Microsoft.Extensions.DependencyInjec_9_tion.dll" FileName="MICROS~6.DLL|Microsoft.Extensions.DependencyInjection.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.DependencyInjection.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Diagnostics.Abstractions.dll" Component_="Microsoft.Extensions.Diagnostics.Abstractions.dll" FileName="MICROS~7.DLL|Microsoft.Extensions.Diagnostics.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Diagnostics.Abstractions.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Diagnostics.dll" Component_="Microsoft.Extensions.Diagnostics.dll" FileName="MICROS~8.DLL|Microsoft.Extensions.Diagnostics.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Diagnostics.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.FileProviders.A_4_bstractions.dll" Component_="Microsoft.Extensions.FileProviders.A_4_bstractions.dll" FileName="MICROS~9.DLL|Microsoft.Extensions.FileProviders.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.FileProviders.Abstractions.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.FileProviders.P_4_hysical.dll" Component_="Microsoft.Extensions.FileProviders.P_4_hysical.dll" FileName="MICRO~10.DLL|Microsoft.Extensions.FileProviders.Physical.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.FileProviders.Physical.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.FileSystemGlobb_4_ing.dll" Component_="Microsoft.Extensions.FileSystemGlobb_4_ing.dll" FileName="MICRO~11.DLL|Microsoft.Extensions.FileSystemGlobbing.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.FileSystemGlobbing.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll" Component_="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll" FileName="MICRO~12.DLL|Microsoft.Extensions.Hosting.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Hosting.Abstractions.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Hosting.dll_4" Component_="Microsoft.Extensions.Hosting.dll_4" FileName="MICRO~13.DLL|Microsoft.Extensions.Hosting.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Hosting.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Logging.Abstrac_4_tions.dll" Component_="Microsoft.Extensions.Logging.Abstrac_4_tions.dll" FileName="MICRO~14.DLL|Microsoft.Extensions.Logging.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.Abstractions.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Logging.Configu_4_ration.dll" Component_="Microsoft.Extensions.Logging.Configu_4_ration.dll" FileName="MICRO~15.DLL|Microsoft.Extensions.Logging.Configuration.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.Configuration.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Logging.Console_4_.dll" Component_="Microsoft.Extensions.Logging.Console_4_.dll" FileName="MICRO~16.DLL|Microsoft.Extensions.Logging.Console.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.Console.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Logging.Debug.dll_4" Component_="Microsoft.Extensions.Logging.Debug.d_12_ll" FileName="MICRO~17.DLL|Microsoft.Extensions.Logging.Debug.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.Debug.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Logging.dll_4" Component_="Microsoft.Extensions.Logging.dll_4" FileName="MICRO~18.DLL|Microsoft.Extensions.Logging.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Logging.EventLo_4_g.dll" Component_="Microsoft.Extensions.Logging.EventLo_4_g.dll" FileName="MICRO~19.DLL|Microsoft.Extensions.Logging.EventLog.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.EventLog.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Logging.EventSo_4_urce.dll" Component_="Microsoft.Extensions.Logging.EventSo_4_urce.dll" FileName="MICRO~20.DLL|Microsoft.Extensions.Logging.EventSource.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.EventSource.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll" Component_="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll" FileName="MICRO~21.DLL|Microsoft.Extensions.Options.ConfigurationExtensions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Options.ConfigurationExtensions.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Options.dll_4" Component_="Microsoft.Extensions.Options.dll_4" FileName="MICRO~22.DLL|Microsoft.Extensions.Options.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Options.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Primitives.dll_4" Component_="Microsoft.Extensions.Primitives.dll_4" FileName="MICRO~23.DLL|Microsoft.Extensions.Primitives.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Primitives.dll" SelfReg="false"/>
     <ROW File="Nice3point.Revit.Extensions.dll_4" Component_="Nice3point.Revit.Extensions.dll_4" FileName="NICE3P~1.DLL|Nice3point.Revit.Extensions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Nice3point.Revit.Extensions.dll" SelfReg="false"/>
     <ROW File="Nice3point.Revit.Toolkit.dll_4" Component_="Nice3point.Revit.Toolkit.dll_4" FileName="NICE3P~2.DLL|Nice3point.Revit.Toolkit.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Nice3point.Revit.Toolkit.dll" SelfReg="false"/>
     <ROW File="ricaun.Revit.UI.StatusBar.1.0.0.dll_4" Component_="ricaun.Revit.UI.StatusBar.1.0.0.dll_4" FileName="RICAUN~1.DLL|ricaun.Revit.UI.StatusBar.1.0.0.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\ricaun.Revit.UI.StatusBar.1.0.0.dll" SelfReg="false"/>
@@ -551,32 +564,14 @@
     <ROW File="Syncfusion.Licensing.dll_4" Component_="Syncfusion.Licensing.dll_4" FileName="SYNCFU~2.DLL|Syncfusion.Licensing.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Syncfusion.Licensing.dll" SelfReg="false"/>
     <ROW File="Syncfusion.SfGrid.WPF.dll_4" Component_="Syncfusion.SfGrid.WPF.dll_4" FileName="SYNCFU~3.DLL|Syncfusion.SfGrid.WPF.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Syncfusion.SfGrid.WPF.dll" SelfReg="false"/>
     <ROW File="Syncfusion.Shared.WPF.dll_4" Component_="Syncfusion.Shared.WPF.dll_4" FileName="SYNCFU~4.DLL|Syncfusion.Shared.WPF.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Syncfusion.Shared.WPF.dll" SelfReg="false"/>
-    <ROW File="SyncNBSParameters.addin_8" Component_="SyncNBSParameters.addin_8" FileName="SYNCNB~1.ADD|SyncNBSParameters.addin" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\SyncNBSParameters.addin" SelfReg="false"/>
-    <ROW File="SyncNBSParameters.deps.json" Component_="SyncNBSParameters.addin_8" FileName="SYNCNB~1.JSO|SyncNBSParameters.deps.json" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\SyncNBSParameters.deps.json" SelfReg="false"/>
+    <ROW File="SyncNBSParameters.deps.json" Component_="SyncNBSParameters.deps.json" FileName="SYNCNB~1.JSO|SyncNBSParameters.deps.json" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\SyncNBSParameters.deps.json" SelfReg="false"/>
     <ROW File="SyncNBSParameters.dll_4" Component_="SyncNBSParameters.dll_4" FileName="SYNCNB~1.DLL|SyncNBSParameters.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\SyncNBSParameters.dll" SelfReg="false"/>
-    <ROW File="SharedParameters.txt_4" Component_="SharedParameters.txt_4" FileName="SHARED~1.TXT|SharedParameters.txt" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Resources\SharedParameters.txt" SelfReg="false"/>
     <ROW File="CommunityToolkit.Mvvm.dll_4" Component_="CommunityToolkit.Mvvm.dll_4" FileName="COMMUN~1.DLL|CommunityToolkit.Mvvm.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\CommunityToolkit.Mvvm.dll" SelfReg="false"/>
     <ROW File="JetBrains.Annotations.dll_4" Component_="JetBrains.Annotations.dll_4" FileName="JETBRA~1.DLL|JetBrains.Annotations.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\JetBrains.Annotations.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Configuration.A_4_bstractions.dll" Component_="Microsoft.Extensions.Configuration.A_4_bstractions.dll" FileName="MICROS~7.DLL|Microsoft.Extensions.Configuration.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.Abstractions.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Configuration.B_4_inder.dll" Component_="Microsoft.Extensions.Configuration.B_4_inder.dll" FileName="MICROS~8.DLL|Microsoft.Extensions.Configuration.Binder.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.Binder.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Configuration.C_4_ommandLine.dll" Component_="Microsoft.Extensions.Configuration.C_4_ommandLine.dll" FileName="MICROS~9.DLL|Microsoft.Extensions.Configuration.CommandLine.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.CommandLine.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Configuration.dll_4" Component_="Microsoft.Extensions.Configuration.d_12_ll" FileName="MICRO~10.DLL|Microsoft.Extensions.Configuration.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll" Component_="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll" FileName="MICRO~11.DLL|Microsoft.Extensions.Configuration.EnvironmentVariables.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll" Component_="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll" FileName="MICRO~12.DLL|Microsoft.Extensions.Configuration.FileExtensions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.FileExtensions.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Configuration.J_4_son.dll" Component_="Microsoft.Extensions.Configuration.J_4_son.dll" FileName="MICRO~13.DLL|Microsoft.Extensions.Configuration.Json.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.Json.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Configuration.U_4_serSecrets.dll" Component_="Microsoft.Extensions.Configuration.U_4_serSecrets.dll" FileName="MICRO~14.DLL|Microsoft.Extensions.Configuration.UserSecrets.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.UserSecrets.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.DependencyInjec_4_tion.Abstractions.dll" Component_="Microsoft.Extensions.DependencyInjec_8_tion.Abstractions.dll" FileName="MICRO~15.DLL|Microsoft.Extensions.DependencyInjection.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.DependencyInjection.Abstractions.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.DependencyInjec_4_tion.dll" Component_="Microsoft.Extensions.DependencyInjec_9_tion.dll" FileName="MICRO~16.DLL|Microsoft.Extensions.DependencyInjection.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.DependencyInjection.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.FileProviders.A_4_bstractions.dll" Component_="Microsoft.Extensions.FileProviders.A_4_bstractions.dll" FileName="MICRO~17.DLL|Microsoft.Extensions.FileProviders.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.FileProviders.Abstractions.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.FileProviders.P_4_hysical.dll" Component_="Microsoft.Extensions.FileProviders.P_4_hysical.dll" FileName="MICRO~18.DLL|Microsoft.Extensions.FileProviders.Physical.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.FileProviders.Physical.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.FileSystemGlobb_4_ing.dll" Component_="Microsoft.Extensions.FileSystemGlobb_4_ing.dll" FileName="MICRO~19.DLL|Microsoft.Extensions.FileSystemGlobbing.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.FileSystemGlobbing.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll" Component_="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll" FileName="MICRO~20.DLL|Microsoft.Extensions.Hosting.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Hosting.Abstractions.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Hosting.dll_4" Component_="Microsoft.Extensions.Hosting.dll_4" FileName="MICRO~21.DLL|Microsoft.Extensions.Hosting.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Hosting.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Logging.Abstrac_4_tions.dll" Component_="Microsoft.Extensions.Logging.Abstrac_4_tions.dll" FileName="MICRO~22.DLL|Microsoft.Extensions.Logging.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.Abstractions.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Logging.Configu_4_ration.dll" Component_="Microsoft.Extensions.Logging.Configu_4_ration.dll" FileName="MICRO~23.DLL|Microsoft.Extensions.Logging.Configuration.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.Configuration.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Logging.Console_4_.dll" Component_="Microsoft.Extensions.Logging.Console_4_.dll" FileName="MICRO~24.DLL|Microsoft.Extensions.Logging.Console.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.Console.dll" SelfReg="false"/>
-    <ROW File="Microsoft.Extensions.Logging.Debug.dll_4" Component_="Microsoft.Extensions.Logging.Debug.d_12_ll" FileName="MICRO~25.DLL|Microsoft.Extensions.Logging.Debug.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Logging.Debug.dll" SelfReg="false"/>
-    <ROW File="SyncNBSParameters.addin_9" Component_="SyncNBSParameters.addin_9" FileName="SYNCNB~1.ADD|SyncNBSParameters.addin" Attributes="0" SourcePath="..\SyncNBSParameters\SyncNBSParameters.addin" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Configuration.A_4_bstractions.dll" Component_="Microsoft.Extensions.Configuration.A_4_bstractions.dll" FileName="MICRO~24.DLL|Microsoft.Extensions.Configuration.Abstractions.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.Abstractions.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Configuration.B_4_inder.dll" Component_="Microsoft.Extensions.Configuration.B_4_inder.dll" FileName="MICRO~25.DLL|Microsoft.Extensions.Configuration.Binder.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.Binder.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Configuration.C_4_ommandLine.dll" Component_="Microsoft.Extensions.Configuration.C_4_ommandLine.dll" FileName="MICRO~26.DLL|Microsoft.Extensions.Configuration.CommandLine.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.CommandLine.dll" SelfReg="false"/>
+    <ROW File="Microsoft.Extensions.Configuration.dll_4" Component_="Microsoft.Extensions.Configuration.d_12_ll" FileName="MICRO~27.DLL|Microsoft.Extensions.Configuration.dll" Attributes="0" SourcePath="..\SyncNBSParameters\bin\Release R25\Microsoft.Extensions.Configuration.dll" SelfReg="false"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.BootstrOptComponent">
     <ROW BootstrOptKey="GlobalOptions" DownloadFolder="[AppDataFolder][|Manufacturer]\[|ProductName]\prerequisites" Options="2"/>
@@ -690,7 +685,6 @@
     <ROW Feature_="MainFeature" Component_="Serilog.Extensions.Logging.dll"/>
     <ROW Feature_="MainFeature" Component_="Serilog.Sinks.Debug.dll"/>
     <ROW Feature_="MainFeature" Component_="Serilog.Sinks.File.dll"/>
-    <ROW Feature_="MainFeature" Component_="SyncNBSParameters.addin_4"/>
     <ROW Feature_="MainFeature" Component_="SyncNBSParameters.dll"/>
     <ROW Feature_="MainFeature" Component_="System.Buffers.dll"/>
     <ROW Feature_="MainFeature" Component_="System.ComponentModel.Annotations.dll"/>
@@ -710,7 +704,6 @@
     <ROW Feature_="MainFeature" Component_="Serilog.Extensions.Logging.dll_1"/>
     <ROW Feature_="MainFeature" Component_="Serilog.Sinks.Debug.dll_1"/>
     <ROW Feature_="MainFeature" Component_="Serilog.Sinks.File.dll_1"/>
-    <ROW Feature_="MainFeature" Component_="SyncNBSParameters.addin_5"/>
     <ROW Feature_="MainFeature" Component_="SyncNBSParameters.dll_1"/>
     <ROW Feature_="MainFeature" Component_="System.Buffers.dll_1"/>
     <ROW Feature_="MainFeature" Component_="System.ComponentModel.Annotations.dll_1"/>
@@ -762,7 +755,6 @@
     <ROW Feature_="MainFeature" Component_="Serilog.Extensions.Logging.dll_2"/>
     <ROW Feature_="MainFeature" Component_="Serilog.Sinks.Debug.dll_2"/>
     <ROW Feature_="MainFeature" Component_="Serilog.Sinks.File.dll_2"/>
-    <ROW Feature_="MainFeature" Component_="SyncNBSParameters.addin_6"/>
     <ROW Feature_="MainFeature" Component_="SyncNBSParameters.dll_2"/>
     <ROW Feature_="MainFeature" Component_="System.Buffers.dll_2"/>
     <ROW Feature_="MainFeature" Component_="System.ComponentModel.Annotations.dll_2"/>
@@ -838,7 +830,6 @@
     <ROW Feature_="MainFeature" Component_="Serilog.Extensions.Logging.dll_3"/>
     <ROW Feature_="MainFeature" Component_="Serilog.Sinks.Debug.dll_3"/>
     <ROW Feature_="MainFeature" Component_="Serilog.Sinks.File.dll_3"/>
-    <ROW Feature_="MainFeature" Component_="SyncNBSParameters.addin_7"/>
     <ROW Feature_="MainFeature" Component_="SyncNBSParameters.dll_3"/>
     <ROW Feature_="MainFeature" Component_="System.Buffers.dll_3"/>
     <ROW Feature_="MainFeature" Component_="System.ComponentModel.Annotations.dll_3"/>
@@ -866,9 +857,27 @@
     <ROW Feature_="MainFeature" Component_="Syncfusion.Licensing.dll_3"/>
     <ROW Feature_="MainFeature" Component_="Syncfusion.SfGrid.WPF.dll_3"/>
     <ROW Feature_="MainFeature" Component_="Syncfusion.Shared.WPF.dll_3"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.J_4_son.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.U_4_serSecrets.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.DependencyInjec_8_tion.Abstractions.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.DependencyInjec_9_tion.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Diagnostics.Abstractions.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Diagnostics.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.FileProviders.A_4_bstractions.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.FileProviders.P_4_hysical.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.FileSystemGlobb_4_ing.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Hosting.dll_4"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.Abstrac_4_tions.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.Configu_4_ration.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.Console_4_.dll"/>
+    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.Debug.d_12_ll"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.dll_4"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.EventLo_4_g.dll"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.EventSo_4_urce.dll"/>
+    <ROW Feature_="MainFeature" Component_="SharedParameters.txt_4"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Options.Configu_4_rationExtensions.dll"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Options.dll_4"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Primitives.dll_4"/>
@@ -884,31 +893,15 @@
     <ROW Feature_="MainFeature" Component_="Syncfusion.Licensing.dll_4"/>
     <ROW Feature_="MainFeature" Component_="Syncfusion.SfGrid.WPF.dll_4"/>
     <ROW Feature_="MainFeature" Component_="Syncfusion.Shared.WPF.dll_4"/>
-    <ROW Feature_="MainFeature" Component_="SyncNBSParameters.addin_8"/>
+    <ROW Feature_="MainFeature" Component_="SyncNBSParameters.deps.json"/>
     <ROW Feature_="MainFeature" Component_="SyncNBSParameters.dll_4"/>
-    <ROW Feature_="MainFeature" Component_="SharedParameters.txt_4"/>
     <ROW Feature_="MainFeature" Component_="CommunityToolkit.Mvvm.dll_4"/>
     <ROW Feature_="MainFeature" Component_="JetBrains.Annotations.dll_4"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.A_4_bstractions.dll"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.B_4_inder.dll"/>
+    <ROW Feature_="MainFeature" Component_="SyncNBSParameters.addin_9"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.C_4_ommandLine.dll"/>
     <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.d_12_ll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.E_4_nvironmentVariables.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.F_4_ileExtensions.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.J_4_son.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Configuration.U_4_serSecrets.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.DependencyInjec_8_tion.Abstractions.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.DependencyInjec_9_tion.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.FileProviders.A_4_bstractions.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.FileProviders.P_4_hysical.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.FileSystemGlobb_4_ing.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Hosting.Abstrac_4_tions.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Hosting.dll_4"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.Abstrac_4_tions.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.Configu_4_ration.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.Console_4_.dll"/>
-    <ROW Feature_="MainFeature" Component_="Microsoft.Extensions.Logging.Debug.d_12_ll"/>
-    <ROW Feature_="MainFeature" Component_="SyncNBSParameters.addin_9"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiInstExSeqComponent">
     <ROW Action="AI_DOWNGRADE" Condition="AI_NEWERPRODUCTFOUND AND (UILevel &lt;&gt; 5)" Sequence="210"/>

--- a/SyncNBSParameters/Commands/CommandAbout.cs
+++ b/SyncNBSParameters/Commands/CommandAbout.cs
@@ -1,19 +1,19 @@
 ﻿using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Nice3point.Revit.Toolkit;
+using Nice3point.Revit.Toolkit.External;
 
 namespace SyncNBSParameters.Commands;
 [Transaction(TransactionMode.Manual)]
-internal class CommandAbout : IExternalCommand
+internal class CommandAbout : ExternalCommand
 {
-    public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+    public override void Execute()
     {
-        App.CachedUiApp = commandData.Application;
-        App.RevitDocument = commandData.Application.ActiveUIDocument.Document;
+        App.CachedUiApp = Context.UiApplication;
+        App.RevitDocument = Context.Document;
 
         var newView = new Views.AboutView();
         newView.ShowDialog();
-
-        return Result.Succeeded;
     }
 }

--- a/SyncNBSParameters/Commands/CommandParameterSync.cs
+++ b/SyncNBSParameters/Commands/CommandParameterSync.cs
@@ -9,21 +9,21 @@ using ricaun.Revit.UI.StatusBar;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Nice3point.Revit.Toolkit.External;
+using Nice3point.Revit.Toolkit;
 
 namespace SyncNBSParameters.Commands;
 
 [Transaction(TransactionMode.Manual)]
-public class CommandParameterSync : IExternalCommand
+public class CommandParameterSync : ExternalCommand
 {
-    public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+    public override void Execute()
     {
-        App.CachedUiApp = commandData.Application;
-        App.RevitDocument = commandData.Application.ActiveUIDocument.Document;
+        App.CachedUiApp = Context.UiApplication;
+        App.RevitDocument = Context.Document;
 
         var newView = new Views.ParameterSyncView();
         newView.ShowDialog();
-
-        return Result.Succeeded;
     }
 
 }

--- a/SyncNBSParameters/Commands/CommandSettings.cs
+++ b/SyncNBSParameters/Commands/CommandSettings.cs
@@ -1,20 +1,20 @@
 ﻿using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Nice3point.Revit.Toolkit;
+using Nice3point.Revit.Toolkit.External;
 
 namespace SyncNBSParameters.Commands;
 
 [Transaction(TransactionMode.Manual)]
-internal class CommandSettings : IExternalCommand
+internal class CommandSettings : ExternalCommand
 {
-    public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+    public override void Execute()
     {
-        App.CachedUiApp = commandData.Application;
-        App.RevitDocument = commandData.Application.ActiveUIDocument.Document;
+        App.CachedUiApp = Context.UiApplication;
+        App.RevitDocument = Context.Document;
 
         var newView = new Views.SettingsView();
         newView.ShowDialog();
-
-        return Result.Succeeded;
     }
 }

--- a/SyncNBSParameters/SyncNBSParameters.csproj
+++ b/SyncNBSParameters/SyncNBSParameters.csproj
@@ -74,22 +74,21 @@
 		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
 		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*" />
 		<PackageReference Include="Nice3point.Revit.Extensions" Version="$(RevitVersion).*" />
-		<PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).0.0" Condition="$(RevitVersion) == '2025'"/>
-		<PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*" Condition="$(RevitVersion) &lt; '2025'"/>
+		<PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*" />
 		<PackageReference Include="ricaun.Revit.UI.StatusBar" Version="1.0.0" />
 		<PackageReference Include="Syncfusion.SfGrid.WPF" Version="24.2.7" />
 
 		<!--IOC-->
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.*" />
-		<!--<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.*" Condition="$(RevitVersion) == '2025'"/>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" Condition="$(RevitVersion) != '' And $(RevitVersion) &lt; '2025'"/>-->
+		<!--<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.*" />-->
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.*" Condition="'$(TargetFramework)' == 'net48'" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
 
 		<!--Logging-->
-		<PackageReference Include="Serilog.Sinks.Debug" Version="2.*"/>
-		<PackageReference Include="Serilog.Sinks.File" Version="5.*"/>
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="7.*" />
-		<!--<PackageReference Include="Serilog.Extensions.Hosting" Version="7.*" Condition="$(RevitVersion) == '2025'"/>
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" Condition="$(RevitVersion) != '' And $(RevitVersion) &lt; '2025'"/>-->
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.*" />
+		<PackageReference Include="Serilog.Sinks.File" Version="5.*" />
+		<!--<PackageReference Include="Serilog.Extensions.Hosting" Version="7.*" />-->
+		<PackageReference Include="Serilog.Extensions.Hosting" Version="7.*" Condition="'$(TargetFramework)' == 'net48'" />
+		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
 	</ItemGroup>
 
 
@@ -104,7 +103,7 @@
 
 	<ItemGroup>
 		<None Update="SyncNBSParameters.addin">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
 		</None>
 		<None Update="Resources\SharedParameters.txt">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
This commit represents a significant overhaul of the project's dependencies and components, aimed at improving functionality, streamlining the installation process, and ensuring compatibility with the latest libraries and tools. Key changes include:

- Updated the `ComponentId` for `ricaun.Revit.UI.StatusBar.1.0.0.dll`, reflecting a revision in component management.
- Removed `SyncNBSParameters.addin` entries across multiple releases (R21 to R24), indicating a decision to streamline or discontinue certain features.
- In Release R25, performed a major update by removing and re-adding various `Microsoft.Extensions.*` DLLs, `SharedParameters.txt`, and `SyncNBSParameters.addin`, suggesting an expansion in software functionality related to configuration management and file handling.
- Conducted a restructuring and cleanup effort by removing and then re-adding `SyncNBSParameters.addin` under a different component ID, aimed at correcting component references and updating dependencies.
- Expanded the project's use of `Microsoft.Extensions.*` libraries in the `MainFeature` section to enhance functionality or incorporate new features.

Refactoring to use `Nice3point.Revit.Toolkit` includes changing the base class for commands in `CommandAbout.cs`, `CommandParameterSync.cs`, and `CommandSettings.cs` from `IExternalCommand` to `ExternalCommand`. This change simplifies command implementation by leveraging the toolkit's features and necessitates the use of `Context.UiApplication` and `Context.Document` instead of direct access.

The `Execute` method in the mentioned command files has been updated to match the signature expected by the `Nice3point.Revit.Toolkit.ExternalCommand` base class, aligning with the toolkit's approach to command execution.

Project file changes for package references include streamlining the inclusion of the `Nice3point.Revit.Toolkit` package, adjusting the handling of `Microsoft.Extensions.Hosting` and `Serilog` packages based on the target framework, and changing the `CopyToOutputDirectory` setting for the `SyncNBSParameters.addin` file from `Always` to `Never`.

Overall, these changes modernize the codebase, improve maintainability, and make the project more flexible and compatible with different environments.