### PR TITLE
Update document context and package versions

### DIFF
--- a/SyncNBSParameters/Commands/CommandAbout.cs
+++ b/SyncNBSParameters/Commands/CommandAbout.cs
@@ -11,7 +11,7 @@ internal class CommandAbout : ExternalCommand
     public override void Execute()
     {
         App.CachedUiApp = Context.UiApplication;
-        App.RevitDocument = Context.Document;
+        App.RevitDocument = Context.ActiveDocument;
 
         var newView = new Views.AboutView();
         newView.ShowDialog();

--- a/SyncNBSParameters/Commands/CommandParameterSync.cs
+++ b/SyncNBSParameters/Commands/CommandParameterSync.cs
@@ -20,7 +20,7 @@ public class CommandParameterSync : ExternalCommand
     public override void Execute()
     {
         App.CachedUiApp = Context.UiApplication;
-        App.RevitDocument = Context.Document;
+        App.RevitDocument = Context.ActiveDocument;
 
         var newView = new Views.ParameterSyncView();
         newView.ShowDialog();

--- a/SyncNBSParameters/Commands/CommandSettings.cs
+++ b/SyncNBSParameters/Commands/CommandSettings.cs
@@ -12,7 +12,7 @@ internal class CommandSettings : ExternalCommand
     public override void Execute()
     {
         App.CachedUiApp = Context.UiApplication;
-        App.RevitDocument = Context.Document;
+        App.RevitDocument = Context.ActiveDocument;
 
         var newView = new Views.SettingsView();
         newView.ShowDialog();

--- a/SyncNBSParameters/SyncNBSParameters.csproj
+++ b/SyncNBSParameters/SyncNBSParameters.csproj
@@ -84,8 +84,8 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
 
 		<!--Logging-->
-		<PackageReference Include="Serilog.Sinks.Debug" Version="3.*" />
-		<PackageReference Include="Serilog.Sinks.File" Version="6.*" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.*" />
+		<PackageReference Include="Serilog.Sinks.File" Version="5.*" />
 		<!--<PackageReference Include="Serilog.Extensions.Hosting" Version="7.*" />-->
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="7.*" Condition="'$(TargetFramework)' == 'net48'" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="8.0.0" />
+    <PackageReference Include="Nuke.Common" Version="8.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Replaced `Context.Document` with `Context.ActiveDocument` in `CommandAbout.cs`, `CommandParameterSync.cs`, and `CommandSettings.cs` for setting `App.RevitDocument`. Updated `SyncNBSParameters.csproj` to use `Microsoft.Extensions.Hosting` version `8.*` for `net8.0-windows`, downgraded `Serilog.Sinks.Debug` to `2.*` and `Serilog.Sinks.File` to `5.*`. Updated `_build.csproj` to use `Nuke.Common` version `8.1.0`.