### PR TITLE
Update dependencies and Advanced Installer version

### DIFF
--- a/Installer/SyncNBSParameters.aip
+++ b/Installer/SyncNBSParameters.aip
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<DOCUMENT Type="Advanced Installer" CreateVersion="21.4" version="23.0.1" Modules="simple" RootPath="." Language="en_GB" Id="{2B827077-80B2-449D-A6AF-D9788483D19C}">
+<DOCUMENT Type="Advanced Installer" CreateVersion="21.4" version="23.2" Modules="simple" RootPath="." Language="en_GB" Id="{2B827077-80B2-449D-A6AF-D9788483D19C}">
   <COMPONENT cid="caphyon.advinst.msicomp.MsiPropsComponent">
     <ROW Property="AI_BITMAP_DISPLAY_MODE" Value="0"/>
     <ROW Property="ALLUSERS" Value="1"/>

--- a/SyncNBSParameters/SyncNBSParameters.csproj
+++ b/SyncNBSParameters/SyncNBSParameters.csproj
@@ -91,24 +91,19 @@
 		<PackageReference Include="ricaun.Revit.UI.StatusBar" Version="1.0.0" />
 		<PackageReference Include="Syncfusion.SfGrid.WPF" Version="29.1.35" />
 
-		<PackageReference Include="System.Text.Json" Version="8.*" />
+		<PackageReference Include="System.Text.Json" Version="10.*" />
 
 		<!--IOC-->
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net48'" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
-
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.*" />
+				  
 		<!--Logging-->
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net48'" />
-		<PackageReference Include="Serilog.Sinks.Debug" Version="3.*" Condition="'$(TargetFramework)' == 'net48'" />
-		<PackageReference Include="Serilog.Sinks.File" Version="6.*" Condition="'$(TargetFramework)' == 'net48'" />
-
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
-		<PackageReference Include="Serilog.Sinks.Debug" Version="3.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
-		<PackageReference Include="Serilog.Sinks.File" Version="6.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
+		<PackageReference Include="Serilog.Extensions.Hosting" Version="10.*" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="3.*"  />
+		<PackageReference Include="Serilog.Sinks.File" Version="7.*" />
 
 		<PackageReference Include="Serilog.Sinks.Async" Version="2.*" />
-
-		<PackageReference Include="Serilog.Sinks.GoogleAnalytics" Version="1.*" />
+		
+		<PackageReference Include="Serilog.Sinks.GoogleAnalytics" Version="1.*" />		
 
 		<!--Repacking-->
 		<!--<PackageVersion Include="ILRepack" Version="2.0.39" ExcludeAssets="Runtime" />-->


### PR DESCRIPTION
Update dependencies and Advanced Installer version

Updated the `SyncNBSParameters.aip` file to reflect a version change in the `Advanced Installer` document from `23.0.1` to `23.2`.

In `SyncNBSParameters.csproj`:
- Updated `System.Text.Json` to `10.*`.
- Updated `Microsoft.Extensions.Hosting` to `10.*` and removed conditional target framework checks.
- Updated `Serilog.Extensions.Hosting` to `10.*` and removed conditional target framework checks.
- Updated `Serilog.Sinks.File` to `7.*` and removed conditional target framework checks.
- Re-added `Serilog.Sinks.GoogleAnalytics` at version `1.*`.
- Retained `Serilog.Sinks.Debug` at `3.*` and `Serilog.Sinks.Async` at `2.*`.
- No changes to `ILRepack`, which remains at `2.0.44`.