### PR TITLE
Update Syncfusion.SfGrid.WPF to floating 29.* version

### DIFF
--- a/SyncNBSParameters/SyncNBSParameters.csproj
+++ b/SyncNBSParameters/SyncNBSParameters.csproj
@@ -89,7 +89,7 @@
 		<PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*" />
 		
 		<PackageReference Include="ricaun.Revit.UI.StatusBar" Version="1.0.0" />
-		<PackageReference Include="Syncfusion.SfGrid.WPF" Version="29.1.35" />
+		<PackageReference Include="Syncfusion.SfGrid.WPF" Version="29.*" />
 
 		<PackageReference Include="System.Text.Json" Version="10.*" />
 


### PR DESCRIPTION
Update Syncfusion.SfGrid.WPF to floating 29.* version

Changed the NuGet package reference for Syncfusion.SfGrid.WPF
from a fixed version (29.1.35) to a floating version (29.*).
This enables automatic adoption of minor and patch updates
within the 29.x.x range, reducing the need for manual updates.